### PR TITLE
feat: add plop-based generator for slice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 dist/
 reports/
+src/generated-to-check

--- a/devtools/generate-templates-to-check.sh
+++ b/devtools/generate-templates-to-check.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+destPath=src/generated-to-check
+rm -rf $destPath
+npm run g:slice toCheck $destPath/slice

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,34 @@
+# Development
+
+### Start development server
+
+```bash
+npm run app:start
+```
+
+### Run jest tests
+
+```bash
+npm run jest:watch # comfortable for development
+```
+
+### Code generation
+
+we use [plop](https://plopjs.com/) tool to generate new files with consistency.
+
+> See details in `plopfile.js` and `templates/` folder
+
+#### Generate redux slice
+
+```bash
+npm run g:slice someListPage src/app/modules/some/pages/some-list-page/state
+# tree src/modules/some/
+src/modules/some/
+└── pages
+    └── some-list-page
+        └── state
+            ├── some-list-page.actions.ts
+            ├── some-list-page.epics.ts
+            ├── some-list-page.reducer.ts
+            └── some-list-page.selectors.ts
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -2737,6 +2737,12 @@
             "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
             "dev": true
         },
+        "@types/fined": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@types/fined/-/fined-1.1.2.tgz",
+            "integrity": "sha512-hzzTS+X9EqDhx4vwdch/DOZci/bfh5J6Nyz8lqvyfBg2ROx2fPafX+LpDfpVgSvQKj0EYkwTYpBO3z2etwbkOw==",
+            "dev": true
+        },
         "@types/glob": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
@@ -2795,6 +2801,25 @@
                 "@types/webpack": "*"
             }
         },
+        "@types/inquirer": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-6.5.0.tgz",
+            "integrity": "sha512-rjaYQ9b9y/VFGOpqBEXRavc3jh0a+e6evAbI31tMda8VlPaSy0AZJfXsvmIe3wklc7W6C3zCSfleuMXR7NOyXw==",
+            "dev": true,
+            "requires": {
+                "@types/through": "*",
+                "rxjs": "^6.4.0"
+            }
+        },
+        "@types/interpret": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@types/interpret/-/interpret-1.1.1.tgz",
+            "integrity": "sha512-HZ4d0m2Ebl8DmrOdYZHgYyipj/8Ftq1/ssB/oQR7fqfUrwtTP7IW3BDi2V445nhPBLzZjEkApaPVp83moSCXlA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/istanbul-lib-coverage": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -2841,6 +2866,17 @@
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
             "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
             "dev": true
+        },
+        "@types/liftoff": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@types/liftoff/-/liftoff-2.5.0.tgz",
+            "integrity": "sha512-1jsThE//wKDK+hYM+NJqswI+K9lfR0YNMctteOxAzk/aemI0rQsVDk6Dia0zkPfBWFTh+hiDmrGQXqP1tyM+eg==",
+            "dev": true,
+            "requires": {
+                "@types/fined": "*",
+                "@types/interpret": "*",
+                "@types/node": "*"
+            }
         },
         "@types/lodash": {
             "version": "4.14.161",
@@ -2959,6 +2995,15 @@
             "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
             "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
             "dev": true
+        },
+        "@types/through": {
+            "version": "0.0.30",
+            "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
+            "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@types/uglify-js": {
             "version": "3.11.0",
@@ -3704,6 +3749,12 @@
             "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
             "dev": true
         },
+        "array-each": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+            "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+            "dev": true
+        },
         "array-find": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
@@ -3791,6 +3842,12 @@
                     "dev": true
                 }
             }
+        },
+        "array-slice": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+            "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
+            "dev": true
         },
         "array-union": {
             "version": "1.0.2",
@@ -5724,6 +5781,87 @@
                 "supports-color": "^5.3.0"
             }
         },
+        "change-case": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.1.0.tgz",
+            "integrity": "sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==",
+            "dev": true,
+            "requires": {
+                "camel-case": "^3.0.0",
+                "constant-case": "^2.0.0",
+                "dot-case": "^2.1.0",
+                "header-case": "^1.0.0",
+                "is-lower-case": "^1.1.0",
+                "is-upper-case": "^1.1.0",
+                "lower-case": "^1.1.1",
+                "lower-case-first": "^1.0.0",
+                "no-case": "^2.3.2",
+                "param-case": "^2.1.0",
+                "pascal-case": "^2.0.0",
+                "path-case": "^2.1.0",
+                "sentence-case": "^2.1.0",
+                "snake-case": "^2.1.0",
+                "swap-case": "^1.1.0",
+                "title-case": "^2.1.0",
+                "upper-case": "^1.1.1",
+                "upper-case-first": "^1.1.0"
+            },
+            "dependencies": {
+                "camel-case": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+                    "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+                    "dev": true,
+                    "requires": {
+                        "no-case": "^2.2.0",
+                        "upper-case": "^1.1.1"
+                    }
+                },
+                "dot-case": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
+                    "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
+                    "dev": true,
+                    "requires": {
+                        "no-case": "^2.2.0"
+                    }
+                },
+                "lower-case": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+                    "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+                    "dev": true
+                },
+                "no-case": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+                    "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+                    "dev": true,
+                    "requires": {
+                        "lower-case": "^1.1.1"
+                    }
+                },
+                "param-case": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+                    "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+                    "dev": true,
+                    "requires": {
+                        "no-case": "^2.2.0"
+                    }
+                },
+                "pascal-case": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
+                    "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+                    "dev": true,
+                    "requires": {
+                        "camel-case": "^3.0.0",
+                        "upper-case-first": "^1.1.0"
+                    }
+                }
+            }
+        },
         "char-regex": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -5928,6 +6066,12 @@
                 "restore-cursor": "^3.1.0"
             }
         },
+        "cli-spinners": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.5.0.tgz",
+            "integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==",
+            "dev": true
+        },
         "cli-truncate": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
@@ -6048,6 +6192,12 @@
                     }
                 }
             }
+        },
+        "clone": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+            "dev": true
         },
         "clone-regexp": {
             "version": "2.2.0",
@@ -6255,6 +6405,16 @@
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
             "dev": true
+        },
+        "constant-case": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
+            "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
+            "dev": true,
+            "requires": {
+                "snake-case": "^2.1.0",
+                "upper-case": "^1.1.1"
+            }
         },
         "content-disposition": {
             "version": "0.5.3",
@@ -6862,6 +7022,15 @@
                 "ip-regex": "^2.1.0"
             }
         },
+        "defaults": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+            "dev": true,
+            "requires": {
+                "clone": "^1.0.2"
+            }
+        },
         "define-properties": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -7199,6 +7368,12 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
             "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+            "dev": true
+        },
+        "detect-file": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+            "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
             "dev": true
         },
         "detect-indent": {
@@ -8234,6 +8409,15 @@
                 }
             }
         },
+        "expand-tilde": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+            "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "^1.0.1"
+            }
+        },
         "expect": {
             "version": "26.5.3",
             "resolved": "https://registry.npmjs.org/expect/-/expect-26.5.3.tgz",
@@ -8824,6 +9008,48 @@
                 "semver-regex": "^2.0.0"
             }
         },
+        "findup-sync": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+            "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+            "dev": true,
+            "requires": {
+                "detect-file": "^1.0.0",
+                "is-glob": "^3.1.0",
+                "micromatch": "^3.0.4",
+                "resolve-dir": "^1.0.1"
+            },
+            "dependencies": {
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.0"
+                    }
+                }
+            }
+        },
+        "fined": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+            "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "^2.0.2",
+                "is-plain-object": "^2.0.3",
+                "object.defaults": "^1.1.0",
+                "object.pick": "^1.2.0",
+                "parse-filepath": "^1.0.1"
+            }
+        },
+        "flagged-respawn": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+            "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
+            "dev": true
+        },
         "flat-cache": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -8852,6 +9078,15 @@
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
             "dev": true
+        },
+        "for-own": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+            "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+            "dev": true,
+            "requires": {
+                "for-in": "^1.0.1"
+            }
         },
         "forever-agent": {
             "version": "0.6.1",
@@ -9105,6 +9340,19 @@
                 }
             }
         },
+        "global-prefix": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+            "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
+            }
+        },
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -9335,6 +9583,33 @@
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true
         },
+        "header-case": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
+            "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
+            "dev": true,
+            "requires": {
+                "no-case": "^2.2.0",
+                "upper-case": "^1.1.3"
+            },
+            "dependencies": {
+                "lower-case": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+                    "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+                    "dev": true
+                },
+                "no-case": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+                    "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+                    "dev": true,
+                    "requires": {
+                        "lower-case": "^1.1.1"
+                    }
+                }
+            }
+        },
         "hex-color-regex": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
@@ -9376,6 +9651,15 @@
             "requires": {
                 "os-homedir": "^1.0.0",
                 "os-tmpdir": "^1.0.1"
+            }
+        },
+        "homedir-polyfill": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+            "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+            "dev": true,
+            "requires": {
+                "parse-passwd": "^1.0.0"
             }
         },
         "hoopy": {
@@ -10065,6 +10349,16 @@
             "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
             "dev": true
         },
+        "is-absolute": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+            "dev": true,
+            "requires": {
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
+            }
+        },
         "is-absolute-url": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
@@ -10300,6 +10594,23 @@
             "integrity": "sha512-18toSebUVF7y717dgw/Dzn6djOCqrkiDp3MhB8P6TdKyCVkbD1ZwE7Uz8Hwx6hUPTvKjbyYH9ncXT4ts4qLaSA==",
             "dev": true
         },
+        "is-lower-case": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
+            "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
+            "dev": true,
+            "requires": {
+                "lower-case": "^1.1.0"
+            },
+            "dependencies": {
+                "lower-case": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+                    "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+                    "dev": true
+                }
+            }
+        },
         "is-negative-zero": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
@@ -10392,6 +10703,15 @@
             "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
             "dev": true
         },
+        "is-relative": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+            "dev": true,
+            "requires": {
+                "is-unc-path": "^1.0.0"
+            }
+        },
         "is-resolvable": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
@@ -10434,6 +10754,24 @@
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
             "dev": true
         },
+        "is-unc-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+            "dev": true,
+            "requires": {
+                "unc-path-regex": "^0.1.2"
+            }
+        },
+        "is-upper-case": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
+            "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
+            "dev": true,
+            "requires": {
+                "upper-case": "^1.1.0"
+            }
+        },
         "is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -10468,6 +10806,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "isbinaryfile": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.6.tgz",
+            "integrity": "sha512-ORrEy+SNVqUhrCaal4hA4fBzhggQQ+BaLntyPOdoEiwlKZW9BZiJXjg3RMiruE4tPEI3pyVPpySHQF/dKWperg==",
             "dev": true
         },
         "isexe": {
@@ -14459,6 +14803,33 @@
                 "type-check": "~0.3.2"
             }
         },
+        "liftoff": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
+            "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+            "dev": true,
+            "requires": {
+                "extend": "^3.0.0",
+                "findup-sync": "^2.0.0",
+                "fined": "^1.0.1",
+                "flagged-respawn": "^1.0.0",
+                "is-plain-object": "^2.0.4",
+                "object.map": "^1.0.0",
+                "rechoir": "^0.6.2",
+                "resolve": "^1.1.7"
+            },
+            "dependencies": {
+                "rechoir": {
+                    "version": "0.6.2",
+                    "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+                    "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+                    "dev": true,
+                    "requires": {
+                        "resolve": "^1.1.6"
+                    }
+                }
+            }
+        },
         "line-column": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/line-column/-/line-column-1.0.2.tgz",
@@ -14882,6 +15253,12 @@
             "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
             "dev": true
         },
+        "lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+            "dev": true
+        },
         "lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -15191,6 +15568,23 @@
                 }
             }
         },
+        "lower-case-first": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
+            "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
+            "dev": true,
+            "requires": {
+                "lower-case": "^1.1.2"
+            },
+            "dependencies": {
+                "lower-case": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+                    "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+                    "dev": true
+                }
+            }
+        },
         "lz-string": {
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
@@ -15202,6 +15596,15 @@
             "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
             "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
             "dev": true
+        },
+        "make-iterator": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+            "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+            "dev": true,
+            "requires": {
+                "kind-of": "^6.0.2"
+            }
         },
         "makeerror": {
             "version": "1.0.11",
@@ -15770,6 +16173,95 @@
                 }
             }
         },
+        "node-plop": {
+            "version": "0.26.2",
+            "resolved": "https://registry.npmjs.org/node-plop/-/node-plop-0.26.2.tgz",
+            "integrity": "sha512-q444beWkMvZwAiYC3BRGJUHgRlpOItQHy+xdy6egXg8KjxDY/Ro309spQTNvH01qK9A8XF6pc0xLKbrHDpxW7w==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.9.2",
+                "@types/inquirer": "^6.5.0",
+                "change-case": "^3.1.0",
+                "del": "^5.1.0",
+                "globby": "^10.0.1",
+                "handlebars": "^4.4.3",
+                "inquirer": "^7.1.0",
+                "isbinaryfile": "^4.0.2",
+                "lodash.get": "^4.4.2",
+                "mkdirp": "^0.5.1",
+                "resolve": "^1.12.0"
+            },
+            "dependencies": {
+                "array-union": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+                    "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+                    "dev": true
+                },
+                "del": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
+                    "integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
+                    "dev": true,
+                    "requires": {
+                        "globby": "^10.0.1",
+                        "graceful-fs": "^4.2.2",
+                        "is-glob": "^4.0.1",
+                        "is-path-cwd": "^2.2.0",
+                        "is-path-inside": "^3.0.1",
+                        "p-map": "^3.0.0",
+                        "rimraf": "^3.0.0",
+                        "slash": "^3.0.0"
+                    }
+                },
+                "globby": {
+                    "version": "10.0.2",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+                    "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/glob": "^7.1.1",
+                        "array-union": "^2.1.0",
+                        "dir-glob": "^3.0.1",
+                        "fast-glob": "^3.0.3",
+                        "glob": "^7.1.3",
+                        "ignore": "^5.1.1",
+                        "merge2": "^1.2.3",
+                        "slash": "^3.0.0"
+                    }
+                },
+                "ignore": {
+                    "version": "5.1.8",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+                    "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+                    "dev": true
+                },
+                "is-path-inside": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+                    "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+                    "dev": true
+                },
+                "p-map": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+                    "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+                    "dev": true,
+                    "requires": {
+                        "aggregate-error": "^3.0.0"
+                    }
+                },
+                "rimraf": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                }
+            }
+        },
         "node-releases": {
             "version": "1.1.39",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.39.tgz",
@@ -16214,6 +16706,18 @@
                 }
             }
         },
+        "object.defaults": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+            "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+            "dev": true,
+            "requires": {
+                "array-each": "^1.0.1",
+                "array-slice": "^1.0.0",
+                "for-own": "^1.0.0",
+                "isobject": "^3.0.0"
+            }
+        },
         "object.entries": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.2.tgz",
@@ -16365,6 +16869,16 @@
                 "es-abstract": "^1.5.1"
             }
         },
+        "object.map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+            "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+            "dev": true,
+            "requires": {
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            }
+        },
         "object.pick": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -16458,6 +16972,65 @@
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2",
                 "word-wrap": "~1.2.3"
+            }
+        },
+        "ora": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
+            "integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.2",
+                "cli-cursor": "^2.1.0",
+                "cli-spinners": "^2.0.0",
+                "log-symbols": "^2.2.0",
+                "strip-ansi": "^5.2.0",
+                "wcwidth": "^1.0.1"
+            },
+            "dependencies": {
+                "cli-cursor": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+                    "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "^2.0.0"
+                    }
+                },
+                "log-symbols": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+                    "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.0.1"
+                    }
+                },
+                "mimic-fn": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+                    "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+                    "dev": true
+                },
+                "onetime": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+                    "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^1.0.0"
+                    }
+                },
+                "restore-cursor": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+                    "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+                    "dev": true,
+                    "requires": {
+                        "onetime": "^2.0.0",
+                        "signal-exit": "^3.0.2"
+                    }
+                }
             }
         },
         "original": {
@@ -16589,6 +17162,17 @@
                 "is-hexadecimal": "^1.0.0"
             }
         },
+        "parse-filepath": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+            "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+            "dev": true,
+            "requires": {
+                "is-absolute": "^1.0.0",
+                "map-cache": "^0.2.0",
+                "path-root": "^0.1.1"
+            }
+        },
         "parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -16598,6 +17182,12 @@
                 "error-ex": "^1.3.1",
                 "json-parse-better-errors": "^1.0.1"
             }
+        },
+        "parse-passwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+            "dev": true
         },
         "parse5": {
             "version": "1.5.1",
@@ -16634,6 +17224,32 @@
             "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
             "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
             "dev": true
+        },
+        "path-case": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
+            "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
+            "dev": true,
+            "requires": {
+                "no-case": "^2.2.0"
+            },
+            "dependencies": {
+                "lower-case": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+                    "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+                    "dev": true
+                },
+                "no-case": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+                    "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+                    "dev": true,
+                    "requires": {
+                        "lower-case": "^1.1.1"
+                    }
+                }
+            }
         },
         "path-dirname": {
             "version": "1.0.2",
@@ -16686,6 +17302,21 @@
                     "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
                 }
             }
+        },
+        "path-root": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+            "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+            "dev": true,
+            "requires": {
+                "path-root-regex": "^0.1.0"
+            }
+        },
+        "path-root-regex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+            "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+            "dev": true
         },
         "path-to-regexp": {
             "version": "0.1.7",
@@ -16780,6 +17411,76 @@
             "dev": true,
             "requires": {
                 "semver-compare": "^1.0.0"
+            }
+        },
+        "plop": {
+            "version": "2.7.4",
+            "resolved": "https://registry.npmjs.org/plop/-/plop-2.7.4.tgz",
+            "integrity": "sha512-SaqN3mwug/Ur2RE/ryo05oLTLy+8qZGwosNt9JnrFWca+dLCsPJR1j2ZXwjrccmNu6LA7eB56lRyk/G0fKf9HA==",
+            "dev": true,
+            "requires": {
+                "@types/liftoff": "^2.5.0",
+                "chalk": "^1.1.3",
+                "interpret": "^1.2.0",
+                "liftoff": "^2.5.0",
+                "minimist": "^1.2.0",
+                "node-plop": "~0.26.2",
+                "ora": "^3.4.0",
+                "v8flags": "^2.0.10"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "interpret": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+                    "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+                    "dev": true
+                },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
             }
         },
         "pngjs": {
@@ -18554,6 +19255,29 @@
                 }
             }
         },
+        "resolve-dir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+            "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
+            },
+            "dependencies": {
+                "global-modules": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+                    "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+                    "dev": true,
+                    "requires": {
+                        "global-prefix": "^1.0.1",
+                        "is-windows": "^1.0.1",
+                        "resolve-dir": "^1.0.0"
+                    }
+                }
+            }
+        },
         "resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -19038,6 +19762,33 @@
                 }
             }
         },
+        "sentence-case": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
+            "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
+            "dev": true,
+            "requires": {
+                "no-case": "^2.2.0",
+                "upper-case-first": "^1.1.2"
+            },
+            "dependencies": {
+                "lower-case": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+                    "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+                    "dev": true
+                },
+                "no-case": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+                    "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+                    "dev": true,
+                    "requires": {
+                        "lower-case": "^1.1.1"
+                    }
+                }
+            }
+        },
         "serialize-javascript": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
@@ -19343,6 +20094,32 @@
                 "ansi-styles": "^3.2.0",
                 "astral-regex": "^1.0.0",
                 "is-fullwidth-code-point": "^2.0.0"
+            }
+        },
+        "snake-case": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
+            "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
+            "dev": true,
+            "requires": {
+                "no-case": "^2.2.0"
+            },
+            "dependencies": {
+                "lower-case": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+                    "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+                    "dev": true
+                },
+                "no-case": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+                    "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+                    "dev": true,
+                    "requires": {
+                        "lower-case": "^1.1.1"
+                    }
+                }
             }
         },
         "snapdragon": {
@@ -20996,6 +21773,24 @@
                 }
             }
         },
+        "swap-case": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
+            "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
+            "dev": true,
+            "requires": {
+                "lower-case": "^1.1.1",
+                "upper-case": "^1.1.1"
+            },
+            "dependencies": {
+                "lower-case": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+                    "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+                    "dev": true
+                }
+            }
+        },
         "symbol-observable": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
@@ -22156,6 +22951,33 @@
             "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
             "dev": true
         },
+        "title-case": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
+            "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
+            "dev": true,
+            "requires": {
+                "no-case": "^2.2.0",
+                "upper-case": "^1.0.3"
+            },
+            "dependencies": {
+                "lower-case": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+                    "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+                    "dev": true
+                },
+                "no-case": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+                    "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+                    "dev": true,
+                    "requires": {
+                        "lower-case": "^1.1.1"
+                    }
+                }
+            }
+        },
         "tmp": {
             "version": "0.0.28",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
@@ -22706,6 +23528,12 @@
             "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
             "dev": true
         },
+        "unc-path-regex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+            "dev": true
+        },
         "unherit": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
@@ -22880,6 +23708,21 @@
             "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
             "dev": true
         },
+        "upper-case": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+            "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+            "dev": true
+        },
+        "upper-case-first": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+            "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+            "dev": true,
+            "requires": {
+                "upper-case": "^1.1.1"
+            }
+        },
         "uri-js": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -22927,6 +23770,12 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+            "dev": true
+        },
+        "user-home": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+            "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
             "dev": true
         },
         "utf8-byte-length": {
@@ -22992,6 +23841,15 @@
                     "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
                     "dev": true
                 }
+            }
+        },
+        "v8flags": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+            "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+            "dev": true,
+            "requires": {
+                "user-home": "^1.1.1"
             }
         },
         "validate-npm-package-license": {
@@ -23116,6 +23974,15 @@
             "dev": true,
             "requires": {
                 "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "wcwidth": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+            "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+            "dev": true,
+            "requires": {
+                "defaults": "^1.0.3"
             }
         },
         "webauth": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "author": "Rodionov Maxim <rodionov.m.m@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "app:build": "rm -rf dist/ && BUILD_MODE=production webpack",
+    "app:build": "run-s -ln app:build:*",
+    "app:build:stage-1": "rm -rf dist/ && npm run g:all-to-check",
+    "app:build:stage-2": " BUILD_MODE=production webpack",
     "app:start": "webpack serve",
     "app:serve": "./devtools/serve.js",
     "eslint:base": "eslint --format=codeframe --max-warnings=0 --ext=js,ts,tsx",
@@ -27,7 +29,9 @@
     "pre-commit": "run-p -ln lint:all",
     "pre-push": "run-s -ln pre-push:stage-1 pre-push:stage-2",
     "pre-push:stage-1": "run-p -ln lint:all app:build jest",
-    "pre-push:stage-2": "run-p -ln testcafe:prod depcruise:validate"
+    "pre-push:stage-2": "run-p -ln testcafe:prod depcruise:validate",
+    "g:slice": "plop slice",
+    "g:all-to-check": "./devtools/generate-templates-to-check.sh"
   },
   "husky": {
     "hooks": {
@@ -101,6 +105,7 @@
     "mini-css-extract-plugin": "1.2.1",
     "node-sass": "4.14.1",
     "npm-run-all": "4.1.5",
+    "plop": "2.7.4",
     "postcss-loader": "4.0.4",
     "prettier": "2.1.2",
     "sass-loader": "10.0.5",

--- a/src/common/redux/action-utils.ts
+++ b/src/common/redux/action-utils.ts
@@ -9,6 +9,16 @@ interface StrictAction<T extends string, P = null> extends Action<T> {
     payload: P
 }
 
+/**
+ * Helper type used in reducers
+ * - when action type contains only one action
+ * - to correctly inferring `never` type in `default:` statement
+ */
+export interface NeverAction {
+    type: never
+    payload?: null
+}
+
 type ActionCreator<T extends string, P> = P extends null
     ? () => { type: T; payload: null }
     : (p: P) => StrictAction<T, P>

--- a/templates/slice/{{dashCase name}}.actions.ts.hbs
+++ b/templates/slice/{{dashCase name}}.actions.ts.hbs
@@ -1,0 +1,8 @@
+
+import { action, ActionsUnion } from 'common/redux/action-utils'
+
+export const {{ camelCase name }}Actions = {
+    {{ firstActionName }}: action('@{{ camelCase name }}.{{ firstActionName }}').withNoPayload(),
+}
+
+export type {{ pascalCase name }}Action = ActionsUnion<typeof {{ camelCase name }}Actions>

--- a/templates/slice/{{dashCase name}}.epics.ts.hbs
+++ b/templates/slice/{{dashCase name}}.epics.ts.hbs
@@ -1,0 +1,13 @@
+import { of } from 'rxjs'
+import { switchMap } from 'rxjs/operators'
+import { Epic, ofType } from 'redux-observable'
+import { {{ pascalCase name }}Action, {{ camelCase name }}Actions } from './{{ dashCase name }}.actions'
+
+export const {{ camelCase name }}Epic: Epic<{{ pascalCase name }}Action> = action$ => {
+    return action$.pipe(
+        ofType('@{{camelCase name}}.{{ firstActionName }}'),
+        switchMap(() => {
+            return of({{ camelCase name }}Actions.{{ firstActionName }}());
+        })
+    )
+}

--- a/templates/slice/{{dashCase name}}.reducer.ts.hbs
+++ b/templates/slice/{{dashCase name}}.reducer.ts.hbs
@@ -1,0 +1,27 @@
+import { StateSlice, storeSlice } from 'common/redux/reducer-utils'
+import { NeverAction } from 'common/redux/action-utils'
+import { shouldNeverBeCalled } from 'common/utils/misc'
+import { {{ pascalCase name }}Action } from './{{ dashCase name }}.actions'
+
+export interface {{ pascalCase name }}State {
+}
+
+const initialState: {{ pascalCase name }}State = {
+}
+
+export type {{ pascalCase name }}StateSlice = StateSlice<typeof {{ camelCase name }}ReducerSlice>
+
+export const {{ camelCase name }}ReducerSlice = storeSlice('{{ camelCase name }}', initialState).withReducer(
+    (state, action: {{ pascalCase name }}Action | NeverAction) => {
+        switch (action.type) {
+            case '@{{ camelCase name }}.{{ firstActionName }}':
+                return {
+                    ...state,
+                }
+
+            default:
+                shouldNeverBeCalled(action)
+        }
+        return state
+    }
+)

--- a/templates/slice/{{dashCase name}}.selectors.ts.hbs
+++ b/templates/slice/{{dashCase name}}.selectors.ts.hbs
@@ -1,0 +1,3 @@
+import { {{ pascalCase name }}StateSlice } from './{{ dashCase name }}.reducer'
+
+export const select{{ pascalCase name }}State = (state: {{ pascalCase name }}StateSlice) => state.{{camelCase name}}


### PR DESCRIPTION
The [plop](https://plopjs.com/)  chosen as generator tool (comparison with other tools see bellow)

## Useful outcomes:
- Create four source files for redux slice in one click:
```
npm run g:slice userList src/modules/user/pages/users-list-page/state
```
or if you forget order of arguments, just answer to few question:
![image](https://user-images.githubusercontent.com/6079597/101591765-43fc0b80-39fe-11eb-8071-faadab1a5da2.png)



- Generator templates **always up to date** since every time the project is built, temporary files are generated for tests and TypeScript validates them like other reqular code
- Dead simple approach to create new generators
- all generated files formatted by prettier


## Comparison with other tools
Criteria:
- :one: tool should do the job
- :two: tool should be as simple as possible: there is enough of everything in the application, so one more technology should not blow up the brain
- :three:  maintainability - tool should be widely used to minimize vendor lock and deprecation

plop, hygen, angular schemantics where compared.

`hygen` and `angular schematics` lost on criteria :two: and at the same time, nothing much better is offered according to criteria :one: :three: (it seems this two is more powerful but it overkill for this applicatoin)

On the other side promts mode in plop is amazing, especially if you rarely generate files :fire: 