### PR TITLE
chore(plop): add template to generate react functional component

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -44,3 +44,20 @@ src/modules/some/
             ├── some-list-page.reducer.ts
             └── some-list-page.selectors.ts
 ```
+
+#### Generate React functional component
+
+```bash
+# positional arguments:
+# - name in dash-case/PascalCase/camelCase
+# - destination folder (without component folder)
+
+npm run g:react-fc fancy-button src/common/ui/
+
+# tree src/common/ui/fancy-button
+src/common/ui/fancy-button
+├── fancy-button.scss
+└── fancy-button.tsx
+```
+
+> NOTE: the generation task automatically adds _component-name_ folder to destination path

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "pre-push:stage-1": "run-p -ln lint:all app:build jest",
     "pre-push:stage-2": "run-p -ln testcafe:prod depcruise:validate",
     "g:slice": "plop slice",
+    "g:react-fc": "plop react-fc",
     "g:all-to-check": "./tools/plop/generate-templates-to-check.sh",
     "cspell:base": "cspell lint --no-progress",
     "cspell:all": "cspell lint --no-progress $(git ls-files)",

--- a/plopfile.js
+++ b/plopfile.js
@@ -12,6 +12,7 @@ module.exports = function (plop) {
     const VALID_NAME = /[\w-]+/
     const INVALID_NAME_PARTS = ['slice', 'store', 'state']
 
+    const SLICE_TEMPLATES_DIR = path.join(TEMPLATE_DIR, 'slice')
     plop.setGenerator('slice', {
         description: 'Generate redux slice source files',
         prompts: [
@@ -42,8 +43,8 @@ module.exports = function (plop) {
             {
                 type: 'addMany',
                 destination: '{{path}}',
-                templateFiles: path.join(TEMPLATE_DIR, 'slice/*.hbs'),
-                base: path.join(TEMPLATE_DIR, '/slice'),
+                templateFiles: path.join(SLICE_TEMPLATES_DIR, '*.hbs'),
+                base: SLICE_TEMPLATES_DIR,
                 transform: template => {
                     return prettierConfigPromise.then(config => {
                         return prettier.format(template, { ...config, parser: 'typescript' })
@@ -52,6 +53,42 @@ module.exports = function (plop) {
                 data: {
                     firstActionName: 'renameMe',
                 },
+            },
+        ],
+    })
+
+    const REACT_FC_TEMPLATES_DIR = path.join(TEMPLATE_DIR, 'react-fc')
+    plop.setGenerator('react-fc', {
+        description: 'Generate react functional component',
+        prompts: [
+            {
+                message:
+                    'React Component name, in any notation: my-component, MyComponent, myComponent',
+                name: 'name',
+                type: 'input',
+                /**
+                 * @param {string} name
+                 */
+                validate: name => {
+                    if (!VALID_NAME.test(name)) {
+                        return `"${name}": name should consist of letters and "-" signs. For ex.: my-component, myComponent`
+                    }
+                    return true
+                },
+            },
+            {
+                message:
+                    'Destination folder where to create component (will be created if not exists)',
+                name: 'path',
+                type: 'input',
+            },
+        ],
+        actions: [
+            {
+                type: 'addMany',
+                destination: '{{path}}/{{dashCase name}}',
+                templateFiles: path.join(REACT_FC_TEMPLATES_DIR, '*.hbs'),
+                base: REACT_FC_TEMPLATES_DIR,
             },
         ],
     })

--- a/tools/plop/templates/react-fc/{{dashCase name}}.scss.hbs
+++ b/tools/plop/templates/react-fc/{{dashCase name}}.scss.hbs
@@ -1,0 +1,3 @@
+.{{dashCase name}} {
+    outline: 1px solid orange;
+}

--- a/tools/plop/templates/react-fc/{{dashCase name}}.tsx.hbs
+++ b/tools/plop/templates/react-fc/{{dashCase name}}.tsx.hbs
@@ -1,0 +1,7 @@
+import './{{dashCase name}}.scss'
+
+interface Props {}
+
+export const {{ pascalCase name}}: React.FC<Props> = props => {
+    return <div className='{{dashCase name}}'></div>
+}


### PR DESCRIPTION

```bash
# positional arguments:
# - name in dash-case/PascalCase/camelCase
# - destination folder (without component folder)

npm run g:react-fc fancy-button src/common/ui/

# tree src/common/ui/fancy-button
src/common/ui/fancy-button
├── fancy-button.scss
└── fancy-button.tsx
```

> NOTE: the generation task automatically adds _component-name_ folder to destination path


https://user-images.githubusercontent.com/6079597/114607383-25a46600-9ca5-11eb-8e1c-73f2e29532b0.mp4

